### PR TITLE
Enable colorization using the `script` command.

### DIFF
--- a/.github/workflows/python-non-master.yml
+++ b/.github/workflows/python-non-master.yml
@@ -35,5 +35,6 @@ jobs:
       run: |
         pylint howdoi *.py --rcfile=.pylintrc
     - name: Test with nose
-      run: |
-        nose2
+      if: runner.os == 'Linux'
+      shell: 'script -q -e -c "bash {0}"'
+      run: nose2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,5 +31,6 @@ jobs:
       run: |
         pylint howdoi *.py --rcfile=.pylintrc
     - name: Test with nose
-      run: |
-        nose2
+      if: runner.os == 'Linux'
+      shell: 'script -q -e -c "bash {0}"'
+      run: nose2

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -196,11 +196,8 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         normal = howdoi.howdoi(query)
         colorized = howdoi.howdoi('-c ' + query)
 
-        # There is currently an issue with Github actions and colorization
-        # so do not run checks if we are running in Github
-        if "GITHUB_ACTION" not in os.environ:
-            self.assertTrue(normal.find('[38;') == -1)
-            self.assertTrue(colorized.find('[38;') != -1)
+        self.assertTrue(normal.find('[38;') == -1)
+        self.assertTrue(colorized.find('[38;') != -1)
 
     # pylint: disable=line-too-long
     def test_get_text_without_links(self):


### PR DESCRIPTION
## Description:

- Tasks solved

- Links to issues solved

## Pull Request type:

- Bug fixes
- New feature
- Improvement
- Refactoring
- Documentation update
- Security fix

## How to test:

Please provide detailed instructions for testing your changes locally, including expected response/behavior.

## Pull Request checklist:

- [ ] Read the [contributing_to_howdoi.md](https://github.com/gleitz/howdoi/blob/master/docs/contributing_to_howdoi.md)
- [ ] Attach screenshots of expected behavior.
- [ ] The changes pass tests locally (`nose2`).
- [ ] There are no linting errors (`python setup.py lint`).
- [ ] The changes don't break existing features.
- [ ] Check that there are no confidential files like `.env` included.
- [ ] Request review from the maintainers.
- [ ] For bug fixes or changes to directory structure, make sure docs are updated.

## Known bugs (if any):

If there are bugs in your current changes you can still open the PR and mention the bugs you found. Propose further changes that can help fix bugs in your current changes.@JohnDaWalka I need to sandbox my iPhone. I'm doing it right now. I'm running everything out to GitHub locally.

## Summary by Sourcery

Enable colorization for the `howdoi` command and update CI workflows to use the `script` command for running tests

New Features:
- Add support for colorization in test output

Enhancements:
- Remove GitHub Actions-specific colorization check in tests

CI:
- Update GitHub Actions workflows to use 'script' command for running tests
- Limit test runs to Linux runners